### PR TITLE
add gd via std git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-assets/portfolios/gd_portfolio.pdf filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
# What
Put GD portfolio as standard file as LFS seemingly does not work with GitHub Pages... It should be ok now as it's still <100MB

# Why
Using Git LFS failed...